### PR TITLE
Add a puppet feed and categories to all puppet posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,3 +14,8 @@ plugins:
   - jekyll-feed
 disqus:
   shortname: alexharv074-github-io
+feed:
+  collections:
+    posts:
+      categories:
+        - puppet

--- a/_posts/2015-12-31-compiling-a-puppet-catalog-on-a-laptop.md
+++ b/_posts/2015-12-31-compiling-a-puppet-catalog-on-a-laptop.md
@@ -3,6 +3,7 @@ layout: post
 title: "Compiling a puppet catalog – on a laptop"
 date: 2015-12-31
 author: Alex Harvey
+category: puppet
 tags: puppet catalog
 ---
 

--- a/_posts/2016-01-02-using-catalog-diff-while-refactoring-puppet-code.md
+++ b/_posts/2016-01-02-using-catalog-diff-while-refactoring-puppet-code.md
@@ -3,6 +3,7 @@ layout: post
 title: "Using catalog-diff while refactoring Puppet code"
 date: 2016-01-02
 author: Alex Harvey
+category: puppet
 tags: puppet refactoring
 ---
 

--- a/_posts/2016-01-03-parallelising-rspec-puppet.md
+++ b/_posts/2016-01-03-parallelising-rspec-puppet.md
@@ -3,6 +3,7 @@ layout: post
 title: "Parallelising rspec-puppet"
 date: 2016-01-03
 author: Alex Harvey
+category: puppet
 tags: puppet rspec
 ---
 

--- a/_posts/2016-03-16-dumping-the-catalog-in-rspec-puppet.md
+++ b/_posts/2016-03-16-dumping-the-catalog-in-rspec-puppet.md
@@ -3,6 +3,7 @@ layout: post
 title: "Dumping the catalog in rspec-puppet"
 date: 2016-03-16
 author: Alex Harvey
+category: puppet
 tags: puppet catalog rspec
 ---
 

--- a/_posts/2016-04-25-speeding-up-beaker-on-a-mac-using-squidman.md
+++ b/_posts/2016-04-25-speeding-up-beaker-on-a-mac-using-squidman.md
@@ -3,6 +3,7 @@ layout: post
 title: "Speeding up Beaker on a Mac using SquidMan"
 date: 2016-04-25
 author: Alex Harvey
+category: puppet
 tags: puppet beaker
 ---
 

--- a/_posts/2016-05-08-setting-up-puppet-module-testing-from-scratch-part-i-puppet-syntax-puppet-lint-and-rspec-puppet.md
+++ b/_posts/2016-05-08-setting-up-puppet-module-testing-from-scratch-part-i-puppet-syntax-puppet-lint-and-rspec-puppet.md
@@ -3,6 +3,7 @@ layout: post
 title: "Setting up Puppet module testing from scratch&#58 Part I, Puppet-syntax, Puppet-lint and Rspec-puppet"
 date: 2016-05-08
 author: Alex Harvey
+category: puppet
 tags: puppet rspec
 ---
 

--- a/_posts/2016-05-13-setting-up-puppet-module-testing-from-scratch-part-ii-beaker-for-module-testing.md
+++ b/_posts/2016-05-13-setting-up-puppet-module-testing-from-scratch-part-ii-beaker-for-module-testing.md
@@ -3,6 +3,7 @@ layout: post
 title: "Setting up Puppet module testing from scratch&#58 Part II, Beaker for module testing"
 date: 2016-05-13
 author: Alex Harvey
+category: puppet
 tags: puppet rspec beaker
 ---
 

--- a/_posts/2016-05-16-setting-up-puppet-module-testing-from-scratch-part-iii-travis-ci.md
+++ b/_posts/2016-05-16-setting-up-puppet-module-testing-from-scratch-part-iii-travis-ci.md
@@ -3,6 +3,7 @@ layout: post
 title: "Setting up Puppet module testing from scratch&#58 Part III, Travis CI"
 date: 2016-05-16
 author: Alex Harvey
+category: puppet
 tags: puppet travis
 ---
 

--- a/_posts/2016-06-26-mocking-with-rspec-puppet-utils.md
+++ b/_posts/2016-06-26-mocking-with-rspec-puppet-utils.md
@@ -3,6 +3,7 @@ layout: post
 title: "Mocking with rspec-puppet-utils"
 date: 2016-06-26
 author: Alex Harvey
+category: puppet
 tags: puppet rspec
 ---
 

--- a/_posts/2016-07-30-verifying-file-contents-in-a-puppet-catalog.md
+++ b/_posts/2016-07-30-verifying-file-contents-in-a-puppet-catalog.md
@@ -3,6 +3,7 @@ layout: post
 title: "Verifying file contents in a puppet catalog"
 date: 2016-07-30
 author: Alex Harvey
+category: puppet
 tags: puppet rspec
 ---
 

--- a/_posts/2016-09-11-introducing-programmatic-editing-of-hiera-yaml-files.md
+++ b/_posts/2016-09-11-introducing-programmatic-editing-of-hiera-yaml-files.md
@@ -3,6 +3,7 @@ layout: post
 title: "Introducing programmatic editing of Hiera YAML files"
 date: 2016-09-11
 author: Alex Harvey
+category: puppet
 tags: puppet hiera ruamel
 ---
 

--- a/_posts/2017-05-31-using-create_specs-to-refactor-puppet.md
+++ b/_posts/2017-05-31-using-create_specs-to-refactor-puppet.md
@@ -3,6 +3,7 @@ layout: post
 title: "Using create_specs to refactor Puppet"
 date: 2017-05-31
 author: Alex Harvey
+category: puppet
 tags: puppet create-specs rspec
 ---
 

--- a/_posts/2017-10-04-merge-a-git-repository-and-its-history-into-a-subdirectory-of-a-second-git-repository.md
+++ b/_posts/2017-10-04-merge-a-git-repository-and-its-history-into-a-subdirectory-of-a-second-git-repository.md
@@ -3,6 +3,7 @@ layout: post
 title: "Merge a Git repository and its history into a subdirectory of a second Git repository"
 date: 2017-10-04
 author: Alex Harvey
+category: puppet
 tags: git puppet
 ---
 

--- a/_posts/2017-11-30-jq-commands-for-puppet-catalogs.md
+++ b/_posts/2017-11-30-jq-commands-for-puppet-catalogs.md
@@ -3,6 +3,7 @@ layout: post
 title: "JQ commands for Puppet catalogs"
 date: 2017-11-30
 author: Alex Harvey
+category: puppet
 tags: puppet catalog jq
 ---
 

--- a/_posts/2018-09-02-pretty-printing-puppet-data.md
+++ b/_posts/2018-09-02-pretty-printing-puppet-data.md
@@ -3,6 +3,7 @@ layout: post
 title: "Pretty-printing Puppet data"
 date: 2018-09-02
 author: Alex Harvey
+category: puppet
 tags: puppet
 ---
 

--- a/_posts/2018-09-06-analysing-puppet-module-dependencies-using-jq.md
+++ b/_posts/2018-09-06-analysing-puppet-module-dependencies-using-jq.md
@@ -3,6 +3,7 @@ layout: post
 title: "Analysing Puppet module dependencies using JQ"
 date: 2018-09-06
 author: Alex Harvey
+category: puppet
 tags: puppet jq
 ---
 

--- a/_posts/2018-09-30-data-consistency-testing-in-puppet-part-i-data-types.md
+++ b/_posts/2018-09-30-data-consistency-testing-in-puppet-part-i-data-types.md
@@ -3,6 +3,7 @@ layout: post
 title: "Data consistency testing in Puppet, Part I: Data types"
 date: 2018-09-30
 author: Alex Harvey
+category: puppet
 tags: puppet data-testing
 ---
 

--- a/_posts/2018-09-30-pros-and-cons-of-pdk.md
+++ b/_posts/2018-09-30-pros-and-cons-of-pdk.md
@@ -3,6 +3,7 @@ layout: post
 title: "The pros and cons of Puppet PDK"
 date: 2018-09-30
 author: Alex Harvey
+category: puppet
 tags: puppet pdk
 ---
 

--- a/_posts/2019-04-13-data-consistency-testing-in-puppet-part-ii-testing-file-content.md
+++ b/_posts/2019-04-13-data-consistency-testing-in-puppet-part-ii-testing-file-content.md
@@ -3,6 +3,7 @@ layout: post
 title: "Data consistency testing in Puppet, Part II: Testing file content"
 date: 2019-04-13
 author: Alex Harvey
+category: puppet
 tags: puppet rspec
 ---
 

--- a/_posts/2019-10-12-adventures-in-the-terraform-dsl-part-viii-the-puppet-provisioner.md
+++ b/_posts/2019-10-12-adventures-in-the-terraform-dsl-part-viii-the-puppet-provisioner.md
@@ -3,6 +3,7 @@ layout: post
 title: "Adventures in the Terraform DSL, Part VIII: The Puppet provisioner"
 date: 2019-10-12
 author: Alex Harvey
+category: puppet
 tags: terraform puppet
 ---
 


### PR DESCRIPTION
Since the jekyll-feed plugin can only filter on categories, this adds the
`category: puppet` to all posts tagged puppet.

Then the `_config.yml` change shows all those posts as a new feed under
`/feed/puppet.xml`.